### PR TITLE
Fit DELETE response with React Admin API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -119,6 +119,8 @@ export default (apiUrl, httpClient = fetchJson) => {
                 };
             case CREATE:
                 return { data: { ...params.data, id: json.id } };
+            case DELETE:
+                return { data: { id: params.id } };
             default:
                 return { data: json };
         }


### PR DESCRIPTION
`validateResponseFormat` throws an error if the response of a DELETE request does not contain `data.id`.